### PR TITLE
fix if e.path is not an array but a NodeList for example

### DIFF
--- a/js/mottle-0.7.3.js
+++ b/js/mottle-0.7.3.js
@@ -29,7 +29,7 @@
     //
         _pi = function(e, target, obj, doCompute) {
             if (!doCompute) return { path:[target], end:1 };
-            else if (typeof e.path !== "undefined") {
+            else if (typeof e.path !== "undefined" && e.path.indexOf) {
                 return { path: e.path, end: e.path.indexOf(obj) };
             } else {
                 var out = { path:[], end:-1 }, _one = function(el) {


### PR DESCRIPTION
I had a problem using jsplumb.  e.path is a NodeList and NodeList doesn't have indexOf method.
It works with this fix.
